### PR TITLE
Refactor BH1750 module to event driven callback design

### DIFF
--- a/src/BH1750/Bh1750Sensor.cpp
+++ b/src/BH1750/Bh1750Sensor.cpp
@@ -1,10 +1,18 @@
 #include "Bh1750Sensor.hpp"
 
+#include <cerrno>
+#include <cstring>
+#include <iostream>
 #include <stdexcept>
+#include <utility>
 
 #include <fcntl.h>
-#include <unistd.h>
+#include <poll.h>
+#include <sys/eventfd.h>
 #include <sys/ioctl.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+
 #include <linux/i2c-dev.h>
 
 namespace {
@@ -17,8 +25,10 @@ constexpr double kLuxDivisor = 1.2;
 Bh1750Sensor::Bh1750Sensor(std::string i2cDevicePath, std::uint8_t i2cAddress)
     : fd_(-1),
       devPath_(std::move(i2cDevicePath)),
-      addr_(i2cAddress) {
-
+      addr_(i2cAddress),
+      callback_(),
+      running_(false),
+      stopFd_(-1) {
     fd_ = ::open(devPath_.c_str(), O_RDWR);
     if (fd_ < 0) {
         throw std::runtime_error("Bh1750Sensor open failed: " + devPath_);
@@ -33,29 +43,152 @@ Bh1750Sensor::Bh1750Sensor(std::string i2cDevicePath, std::uint8_t i2cAddress)
     writeCommand(kCmdPowerOn);
     writeCommand(kCmdReset);
     writeCommand(kCmdContinuousHighRes);
+
+    stopFd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (stopFd_ < 0) {
+        ::close(fd_);
+        fd_ = -1;
+        throw std::runtime_error("Bh1750Sensor eventfd failed");
+    }
 }
 
 Bh1750Sensor::~Bh1750Sensor() {
+    stop();
+
+    if (stopFd_ >= 0) {
+        ::close(stopFd_);
+        stopFd_ = -1;
+    }
+
     if (fd_ >= 0) {
         ::close(fd_);
         fd_ = -1;
     }
 }
 
+void Bh1750Sensor::registerCallback(LightLevelCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    callback_ = std::move(callback);
+}
+
+void Bh1750Sensor::start(int intervalMs) {
+    if (intervalMs <= 0) {
+        throw std::invalid_argument("intervalMs must be > 0");
+    }
+    if (running_) {
+        throw std::logic_error("Bh1750Sensor already running");
+    }
+
+    std::uint64_t drained = 0;
+    while (::read(stopFd_, &drained, sizeof(drained)) == static_cast<ssize_t>(sizeof(drained))) {
+    }
+
+    running_ = true;
+    worker_ = std::thread(&Bh1750Sensor::runLoop, this, intervalMs);
+}
+
+void Bh1750Sensor::stop() {
+    if (!running_) {
+        return;
+    }
+
+    running_ = false;
+
+    const std::uint64_t one = 1;
+    (void)::write(stopFd_, &one, sizeof(one));
+
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
 void Bh1750Sensor::writeCommand(std::uint8_t cmd) {
-    int rc = ::write(fd_, &cmd, 1);
+    const int rc = ::write(fd_, &cmd, 1);
     if (rc != 1) {
         throw std::runtime_error("Bh1750Sensor write command failed");
     }
 }
 
-double Bh1750Sensor::readLux() {
+double Bh1750Sensor::readLuxOnce() {
     std::uint8_t buf[2] = {0, 0};
-    int rc = ::read(fd_, buf, 2);
+    const int rc = ::read(fd_, buf, 2);
     if (rc != 2) {
         throw std::runtime_error("Bh1750Sensor read failed");
     }
 
-    std::uint16_t raw = static_cast<std::uint16_t>(buf[0] << 8) | buf[1];
+    const std::uint16_t raw =
+        static_cast<std::uint16_t>((static_cast<std::uint16_t>(buf[0]) << 8) | buf[1]);
+
     return static_cast<double>(raw) / kLuxDivisor;
+}
+
+void Bh1750Sensor::runLoop(int intervalMs) {
+    const int tfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+    if (tfd < 0) {
+        std::cerr << "Bh1750Sensor timerfd_create failed\n";
+        running_ = false;
+        return;
+    }
+
+    itimerspec its{};
+    its.it_value.tv_sec = intervalMs / 1000;
+    its.it_value.tv_nsec = (intervalMs % 1000) * 1000000;
+    its.it_interval = its.it_value;
+
+    if (timerfd_settime(tfd, 0, &its, nullptr) != 0) {
+        std::cerr << "Bh1750Sensor timerfd_settime failed\n";
+        ::close(tfd);
+        running_ = false;
+        return;
+    }
+
+    pollfd fds[2]{};
+    fds[0].fd = tfd;
+    fds[0].events = POLLIN;
+    fds[1].fd = stopFd_;
+    fds[1].events = POLLIN;
+
+    while (running_) {
+        const int rc = ::poll(fds, 2, -1);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            std::cerr << "Bh1750Sensor poll failed: " << std::strerror(errno) << "\n";
+            break;
+        }
+
+        if (fds[1].revents & POLLIN) {
+            std::uint64_t stopValue = 0;
+            (void)::read(stopFd_, &stopValue, sizeof(stopValue));
+            break;
+        }
+
+        if (fds[0].revents & POLLIN) {
+            std::uint64_t expirations = 0;
+            if (::read(tfd, &expirations, sizeof(expirations)) != static_cast<ssize_t>(sizeof(expirations))) {
+                continue;
+            }
+
+            try {
+                const double lux = readLuxOnce();
+
+                LightLevelCallback callbackCopy;
+                {
+                    std::lock_guard<std::mutex> lock(callbackMutex_);
+                    callbackCopy = callback_;
+                }
+
+                if (callbackCopy) {
+                    callbackCopy(lux);
+                }
+            }
+            catch (const std::exception& e) {
+                std::cerr << "Bh1750Sensor sample error: " << e.what() << "\n";
+            }
+        }
+    }
+
+    ::close(tfd);
+    running_ = false;
 }

--- a/src/BH1750/CMakeLists.txt
+++ b/src/BH1750/CMakeLists.txt
@@ -1,21 +1,31 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(pi_fridge_rpi_sensors LANGUAGES CXX)
+project(pi_fridge_bh1750 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(pifridge_logic INTERFACE)
-target_include_directories(pifridge_logic INTERFACE
+enable_testing()
+
+find_package(Threads REQUIRED)
+
+add_library(pifridge_light_logic STATIC
+    ILightSensor.cpp
+    DoorLightController.cpp
+)
+
+target_include_directories(pifridge_light_logic PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 add_executable(door_light_controller_test
-    tests/DoorLightControllerTest.cpp
+    test/DoorLightControllerTest.cpp
 )
-target_link_libraries(door_light_controller_test PRIVATE pifridge_logic)
 
-enable_testing()
+target_link_libraries(door_light_controller_test PRIVATE
+    pifridge_light_logic
+)
+
 add_test(NAME door_light_controller_test COMMAND door_light_controller_test)
 
 option(PIFRIDGE_BUILD_HARDWARE "Build Raspberry Pi hardware implementations" OFF)
@@ -29,10 +39,9 @@ if(PIFRIDGE_BUILD_HARDWARE)
     check_cxx_source_compiles("#include <gpiod.h>\nint main(){ (void)&gpiod_chip_request_lines; return 0; }\n" PIFRIDGE_HAVE_GPIOD_V2)
     unset(CMAKE_REQUIRED_INCLUDES)
 
-
     add_library(pifridge_rpi_hw STATIC
-        src/Bh1750Sensor.cpp
-        src/GpioOutput.cpp
+        Bh1750Sensor.cpp
+        GpioOutput.cpp
     )
 
     target_include_directories(pifridge_rpi_hw PUBLIC
@@ -45,7 +54,8 @@ if(PIFRIDGE_BUILD_HARDWARE)
     )
 
     target_link_libraries(pifridge_rpi_hw PUBLIC
-        pifridge_logic
+        pifridge_light_logic
+        Threads::Threads
         ${GPIOD_LIBRARIES}
     )
 
@@ -59,9 +69,11 @@ if(PIFRIDGE_BUILD_HARDWARE)
         target_compile_definitions(pifridge_rpi_hw PUBLIC PIFRIDGE_GPIOD_V2=0)
     endif()
 
-
     add_executable(pifridge_light_sensor_demo
-        src/main.cpp
+        main.cpp
     )
-    target_link_libraries(pifridge_light_sensor_demo PRIVATE pifridge_rpi_hw)
+
+    target_link_libraries(pifridge_light_sensor_demo PRIVATE
+        pifridge_rpi_hw
+    )
 endif()

--- a/src/BH1750/DoorLightController.cpp
+++ b/src/BH1750/DoorLightController.cpp
@@ -1,0 +1,52 @@
+#include "DoorLightController.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+DoorLightController::DoorLightController(IGpioOutput& gpio,
+                                         double openThresholdLux,
+                                         double closeThresholdLux)
+    : gpio_(gpio),
+      openThresholdLux_(openThresholdLux),
+      closeThresholdLux_(closeThresholdLux),
+      isOpen_(false),
+      lastLux_(-1.0) {
+    if (closeThresholdLux_ > openThresholdLux_) {
+        throw std::invalid_argument("close threshold must be <= open threshold");
+    }
+}
+
+void DoorLightController::hasLightSample(double lux) {
+    lastLux_ = lux;
+
+    if (!isOpen_ && lux >= openThresholdLux_) {
+        isOpen_ = true;
+        gpio_.setHigh();
+        notifyDoorState(true, lux);
+        return;
+    }
+
+    if (isOpen_ && lux <= closeThresholdLux_) {
+        isOpen_ = false;
+        gpio_.setLow();
+        notifyDoorState(false, lux);
+    }
+}
+
+void DoorLightController::registerDoorStateCallback(DoorStateCallback callback) {
+    doorStateCallback_ = std::move(callback);
+}
+
+bool DoorLightController::isDoorOpen() const {
+    return isOpen_;
+}
+
+double DoorLightController::lastLux() const {
+    return lastLux_;
+}
+
+void DoorLightController::notifyDoorState(bool isOpen, double lux) {
+    if (doorStateCallback_) {
+        doorStateCallback_(isOpen, lux);
+    }
+}

--- a/src/BH1750/ILightSensor.cpp
+++ b/src/BH1750/ILightSensor.cpp
@@ -1,0 +1,3 @@
+#include "ILightSensor.hpp"
+
+ILightSensor::~ILightSensor() = default;

--- a/src/BH1750/include/Bh1750Sensor.hpp
+++ b/src/BH1750/include/Bh1750Sensor.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "ILightSensor.hpp"
 
@@ -15,12 +18,21 @@ public:
     Bh1750Sensor(const Bh1750Sensor&) = delete;
     Bh1750Sensor& operator=(const Bh1750Sensor&) = delete;
 
-    double readLux() override;
+    void registerCallback(LightLevelCallback callback) override;
+    void start(int intervalMs) override;
+    void stop() override;
 
 private:
     void writeCommand(std::uint8_t cmd);
+    double readLuxOnce();
+    void runLoop(int intervalMs);
 
     int fd_;
     std::string devPath_;
     std::uint8_t addr_;
+    std::mutex callbackMutex_;
+    LightLevelCallback callback_;
+    std::atomic<bool> running_;
+    int stopFd_;
+    std::thread worker_;
 };

--- a/src/BH1750/include/DoorLightController.hpp
+++ b/src/BH1750/include/DoorLightController.hpp
@@ -1,48 +1,30 @@
 #pragma once
 
-#include "ILightSensor.hpp"
+#include <functional>
+
 #include "IGpioOutput.hpp"
 
 class DoorLightController {
 public:
-    DoorLightController(ILightSensor& sensor,
-                        IGpioOutput& gpio,
+    using DoorStateCallback = std::function<void(bool, double)>;
+
+    DoorLightController(IGpioOutput& gpio,
                         double openThresholdLux,
-                        double closeThresholdLux)
-        : sensor_(sensor),
-          gpio_(gpio),
-          openThresholdLux_(openThresholdLux),
-          closeThresholdLux_(closeThresholdLux),
-          isOpen_(false),
-          lastLux_(-1.0) {}
+                        double closeThresholdLux);
 
-    void update() {
-        double lux = sensor_.readLux();
-        lastLux_ = lux;
+    void hasLightSample(double lux);
+    void registerDoorStateCallback(DoorStateCallback callback);
 
-        if (!isOpen_ && lux >= openThresholdLux_) {
-            isOpen_ = true;
-            gpio_.setHigh();
-        }
-        else if (isOpen_ && lux <= closeThresholdLux_) {
-            isOpen_ = false;
-            gpio_.setLow();
-        }
-    }
-
-    bool isDoorOpen() const {
-        return isOpen_;
-    }
-
-    double lastLux() const {
-        return lastLux_;
-    }
+    bool isDoorOpen() const;
+    double lastLux() const;
 
 private:
-    ILightSensor& sensor_;
+    void notifyDoorState(bool isOpen, double lux);
+
     IGpioOutput& gpio_;
     double openThresholdLux_;
     double closeThresholdLux_;
     bool isOpen_;
     double lastLux_;
+    DoorStateCallback doorStateCallback_;
 };

--- a/src/BH1750/include/ILightSensor.hpp
+++ b/src/BH1750/include/ILightSensor.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <functional>
+
 class ILightSensor {
 public:
-    virtual ~ILightSensor() = default;
+    using LightLevelCallback = std::function<void(double)>;
 
-    // Returns current light level in lux
-    virtual double readLux() = 0;
+    virtual ~ILightSensor();
+
+    virtual void registerCallback(LightLevelCallback callback) = 0;
+    virtual void start(int intervalMs) = 0;
+    virtual void stop() = 0;
 };

--- a/src/BH1750/main.cpp
+++ b/src/BH1750/main.cpp
@@ -1,22 +1,16 @@
 #include "Bh1750Sensor.hpp"
-#include "GpioOutput.hpp"
 #include "DoorLightController.hpp"
+#include "GpioOutput.hpp"
 
 #include <cerrno>
 #include <csignal>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
-#include <sys/epoll.h>
 #include <sys/signalfd.h>
-#include <sys/timerfd.h>
 #include <unistd.h>
-#include <poll.h>
-#include <thread>
-#include <sys/eventfd.h>
 
 static void printUsage(const char* argv0) {
     std::cout
@@ -24,7 +18,7 @@ static void printUsage(const char* argv0) {
         << "Options:\n"
         << "  --open <lux>          Open threshold lux (default 30)\n"
         << "  --close <lux>         Close threshold lux (default 10)\n"
-        << "  --interval-ms <ms>    Update interval in ms (default 200)\n"
+        << "  --interval-ms <ms>    Sample interval in ms (default 200)\n"
         << "  --i2c-dev <path>      I2C device path (default /dev/i2c-1)\n"
         << "  --i2c-addr <hex>      I2C address hex (default 0x23)\n"
         << "  --gpio-chip <name>    gpiochip name (default gpiochip0)\n"
@@ -39,11 +33,15 @@ static bool hasPrefix(const std::string& s, const std::string& p) {
 static std::uint8_t parseHexByte(const std::string& s) {
     std::size_t idx = 0;
     int base = 10;
-    if (hasPrefix(s, "0x") || hasPrefix(s, "0X")) base = 16;
-    unsigned long v = std::stoul(s, &idx, base);
+    if (hasPrefix(s, "0x") || hasPrefix(s, "0X")) {
+        base = 16;
+    }
+
+    const unsigned long v = std::stoul(s, &idx, base);
     if (idx != s.size() || v > 0xFF) {
         throw std::runtime_error("invalid hex byte: " + s);
     }
+
     return static_cast<std::uint8_t>(v);
 }
 
@@ -60,8 +58,8 @@ int main(int argc, char** argv) {
     bool activeHigh = true;
 
     try {
-        for (int i = 1; i < argc; i++) {
-            std::string a = argv[i];
+        for (int i = 1; i < argc; ++i) {
+            const std::string a = argv[i];
 
             auto needValue = [&](const std::string& name) -> std::string {
                 if (i + 1 >= argc) {
@@ -70,14 +68,30 @@ int main(int argc, char** argv) {
                 return std::string(argv[++i]);
             };
 
-            if (a == "--open") openLux = std::stod(needValue(a));
-            else if (a == "--close") closeLux = std::stod(needValue(a));
-            else if (a == "--interval-ms") intervalMs = std::stoi(needValue(a));
-            else if (a == "--i2c-dev") i2cDev = needValue(a);
-            else if (a == "--i2c-addr") i2cAddr = parseHexByte(needValue(a));
-            else if (a == "--gpio-chip") gpioChip = needValue(a);
-            else if (a == "--gpio-line") gpioLine = static_cast<unsigned int>(std::stoul(needValue(a)));
-            else if (a == "--active-low") activeHigh = false;
+            if (a == "--open") {
+                openLux = std::stod(needValue(a));
+            }
+            else if (a == "--close") {
+                closeLux = std::stod(needValue(a));
+            }
+            else if (a == "--interval-ms") {
+                intervalMs = std::stoi(needValue(a));
+            }
+            else if (a == "--i2c-dev") {
+                i2cDev = needValue(a);
+            }
+            else if (a == "--i2c-addr") {
+                i2cAddr = parseHexByte(needValue(a));
+            }
+            else if (a == "--gpio-chip") {
+                gpioChip = needValue(a);
+            }
+            else if (a == "--gpio-line") {
+                gpioLine = static_cast<unsigned int>(std::stoul(needValue(a)));
+            }
+            else if (a == "--active-low") {
+                activeHigh = false;
+            }
             else if (a == "--help" || a == "-h") {
                 printUsage(argv[0]);
                 return 0;
@@ -87,11 +101,11 @@ int main(int argc, char** argv) {
             }
         }
 
-        if (closeLux > openLux) {
-            throw std::runtime_error("close threshold must be <= open threshold");
-        }
         if (intervalMs <= 0) {
             throw std::runtime_error("interval-ms must be > 0");
+        }
+        if (closeLux > openLux) {
+            throw std::runtime_error("close threshold must be <= open threshold");
         }
     }
     catch (const std::exception& e) {
@@ -110,125 +124,32 @@ int main(int argc, char** argv) {
             throw std::runtime_error("sigprocmask failed");
         }
 
-        int sfd = signalfd(-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC);
+        const int sfd = signalfd(-1, &mask, SFD_CLOEXEC);
         if (sfd < 0) {
             throw std::runtime_error("signalfd failed");
         }
 
-        int tfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
-        if (tfd < 0) {
-            ::close(sfd);
-            throw std::runtime_error("timerfd_create failed");
-        }
-
-        itimerspec its{};
-        its.it_value.tv_sec = intervalMs / 1000;
-        its.it_value.tv_nsec = (intervalMs % 1000) * 1000000;
-        its.it_interval = its.it_value;
-
-        if (timerfd_settime(tfd, 0, &its, nullptr) != 0) {
-            ::close(tfd);
-            ::close(sfd);
-            throw std::runtime_error("timerfd_settime failed");
-        }
-
-        int ep = epoll_create1(EPOLL_CLOEXEC);
-        if (ep < 0) {
-            ::close(tfd);
-            ::close(sfd);
-            throw std::runtime_error("epoll_create1 failed");
-        }
-
-        epoll_event evTimer{};
-        evTimer.events = EPOLLIN;
-        evTimer.data.u32 = 1;
-        if (epoll_ctl(ep, EPOLL_CTL_ADD, tfd, &evTimer) != 0) {
-            ::close(ep);
-            ::close(tfd);
-            ::close(sfd);
-            throw std::runtime_error("epoll_ctl add timer failed");
-        }
-
-        epoll_event evSig{};
-        evSig.events = EPOLLIN;
-        evSig.data.u32 = 2;
-        if (epoll_ctl(ep, EPOLL_CTL_ADD, sfd, &evSig) != 0) {
-            ::close(ep);
-            ::close(tfd);
-            ::close(sfd);
-            throw std::runtime_error("epoll_ctl add signal failed");
-        }
-
         Bh1750Sensor sensor(i2cDev, i2cAddr);
         GpioOutput gpio(gpioChip, gpioLine, activeHigh);
-        DoorLightController ctl(sensor, gpio, openLux, closeLux);
+        DoorLightController controller(gpio, openLux, closeLux);
 
-        
-        // Worker thread: run controller updates when main loop signals a tick.
-        struct ControllerWorker {
-            int tick_fd;
-            int stop_fd;
-            std::thread th;
+        controller.registerDoorStateCallback([](bool isOpen, double lux) {
+            std::cout
+                << "door=" << (isOpen ? "open" : "closed")
+                << " lux=" << lux
+                << "\n";
+        });
 
-            explicit ControllerWorker(DoorLightController& ctl_ref)
-                : tick_fd(eventfd(0, EFD_CLOEXEC)),
-                  stop_fd(eventfd(0, EFD_CLOEXEC)) {
-                if (tick_fd < 0 || stop_fd < 0) {
-                    std::perror("eventfd");
-                    std::exit(1);
-                }
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
 
-                th = std::thread([&ctl_ref, this] {
-                    pollfd fds[2] = {
-                        { tick_fd, POLLIN, 0 },
-                        { stop_fd, POLLIN, 0 },
-                    };
-
-                    while (true) {
-                        int rc = poll(fds, 2, -1);
-                        if (rc < 0) {
-                            if (errno == EINTR) continue;
-                            std::perror("poll");
-                            return;
-                        }
-
-                        if (fds[1].revents & POLLIN) {
-                            uint64_t v;
-                            (void)read(stop_fd, &v, sizeof(v));
-                            return;
-                        }
-
-                        if (fds[0].revents & POLLIN) {
-                            uint64_t v;
-                            if (read(tick_fd, &v, sizeof(v)) == (ssize_t)sizeof(v)) {
-                                ctl_ref.update();
-                            }
-                        }
-                    }
-                });
-            }
-
-            void notify_tick() const {
-                uint64_t one = 1;
-                (void)write(tick_fd, &one, sizeof(one));
-            }
-
-            ~ControllerWorker() {
-                uint64_t one = 1;
-                if (stop_fd >= 0) (void)write(stop_fd, &one, sizeof(one));
-                if (th.joinable()) th.join();
-                if (tick_fd >= 0) close(tick_fd);
-                if (stop_fd >= 0) close(stop_fd);
-            }
-        };
-
-        ControllerWorker worker(ctl);
-
-bool lastOpen = ctl.isDoorOpen();
+        sensor.start(intervalMs);
 
         std::cout
             << "PiFridge light sensor demo running\n"
-            << "open=" << openLux << " close=" << closeLux
+            << "open=" << openLux
+            << " close=" << closeLux
             << " intervalMs=" << intervalMs
             << " i2cDev=" << i2cDev
             << " i2cAddr=0x" << std::hex << static_cast<int>(i2cAddr) << std::dec
@@ -238,41 +159,28 @@ bool lastOpen = ctl.isDoorOpen();
             << "\n";
 
         while (true) {
-            epoll_event events[4]{};
-            int n = epoll_wait(ep, events, 4, -1);
-            if (n < 0) {
-                if (errno == EINTR) continue;
-                throw std::runtime_error("epoll_wait failed");
+            signalfd_siginfo si{};
+            const ssize_t rc = ::read(sfd, &si, sizeof(si));
+
+            if (rc < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                sensor.stop();
+                ::close(sfd);
+                throw std::runtime_error("read from signalfd failed");
             }
 
-            for (int i = 0; i < n; i++) {
-                if (events[i].data.u32 == 2) {
-                    signalfd_siginfo si{};
-                    ::read(sfd, &si, sizeof(si));
-                    std::cout << "Stopping\n";
-                    ::close(ep);
-                    ::close(tfd);
-                    ::close(sfd);
-                    return 0;
-                }
-
-                if (events[i].data.u32 == 1) {
-                    std::uint64_t ticks = 0;
-                    ::read(tfd, &ticks, sizeof(ticks));
-
-                    worker.notify_tick();
-
-                    bool nowOpen = ctl.isDoorOpen();
-                    if (nowOpen != lastOpen) {
-                        std::cout
-                            << "door=" << (nowOpen ? "open" : "closed")
-                            << " lux=" << ctl.lastLux()
-                            << "\n";
-                        lastOpen = nowOpen;
-                    }
-                }
+            if (rc == static_cast<ssize_t>(sizeof(si)) &&
+                (si.ssi_signo == SIGINT || si.ssi_signo == SIGTERM)) {
+                std::cout << "Stopping\n";
+                break;
             }
         }
+
+        sensor.stop();
+        ::close(sfd);
+        return 0;
     }
     catch (const std::exception& e) {
         std::cout << "Fatal: " << e.what() << "\n";

--- a/src/BH1750/test/DoorLightControllerTest.cpp
+++ b/src/BH1750/test/DoorLightControllerTest.cpp
@@ -1,42 +1,59 @@
+#include <cmath>
 #include <iostream>
-#include <vector>
 #include <string>
+#include <utility>
 
 #include "../include/DoorLightController.hpp"
+#include "../include/ILightSensor.hpp"
 
 class FakeLightSensor : public ILightSensor {
 public:
-    explicit FakeLightSensor(std::vector<double> luxSequence)
-        : lux_(std::move(luxSequence)), idx_(0) {}
+    void registerCallback(LightLevelCallback callback) override {
+        callback_ = std::move(callback);
+    }
 
-    double readLux() override {
-        if (lux_.empty()) return 0.0;
-        if (idx_ >= lux_.size()) return lux_.back();
-        return lux_[idx_++];
+    void start(int) override {
+    }
+
+    void stop() override {
+    }
+
+    void emit(double lux) {
+        if (callback_) {
+            callback_(lux);
+        }
     }
 
 private:
-    std::vector<double> lux_;
-    std::size_t idx_;
+    LightLevelCallback callback_;
 };
 
 class FakeGpioOutput : public IGpioOutput {
 public:
-    FakeGpioOutput() : high_(false), highCalls_(0), lowCalls_(0) {}
+    FakeGpioOutput() : high_(false), highCalls_(0), lowCalls_(0) {
+    }
 
     void setHigh() override {
         high_ = true;
-        highCalls_++;
+        ++highCalls_;
     }
 
     void setLow() override {
         high_ = false;
-        lowCalls_++;
+        ++lowCalls_;
     }
 
-    bool isHigh() const { return high_; }
-    int highCalls() const { return highCalls_; }
-    int lowCalls() const { return lowCalls_; }
+    bool isHigh() const {
+        return high_;
+    }
+
+    int highCalls() const {
+        return highCalls_;
+    }
+
+    int lowCalls() const {
+        return lowCalls_;
+    }
 
 private:
     bool high_;
@@ -44,87 +61,131 @@ private:
     int lowCalls_;
 };
 
-static int g_failures = 0;
-
-static void expectTrue(bool cond, const std::string& msg) {
-    if (!cond) {
-        std::cout << "FAIL: " << msg << "\n";
-        g_failures++;
-    }
-}
-
-static void expectEqInt(int a, int b, const std::string& msg) {
-    if (a != b) {
-        std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
-        g_failures++;
-    }
-}
-
 int main() {
+    int failures = 0;
+
+    auto expectTrue = [&](bool cond, const std::string& msg) {
+        if (!cond) {
+            std::cout << "FAIL: " << msg << "\n";
+            ++failures;
+        }
+    };
+
+    auto expectEqInt = [&](int a, int b, const std::string& msg) {
+        if (a != b) {
+            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
+            ++failures;
+        }
+    };
+
+    auto expectNear = [&](double a, double b, const std::string& msg) {
+        if (std::fabs(a - b) > 1e-9) {
+            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
+            ++failures;
+        }
+    };
+
     {
-        FakeLightSensor sensor({0.0, 5.0, 9.0});
+        FakeLightSensor sensor;
         FakeGpioOutput gpio;
-        DoorLightController ctl(sensor, gpio, 30.0, 10.0);
+        DoorLightController controller(gpio, 30.0, 10.0);
 
-        ctl.update();
-        ctl.update();
-        ctl.update();
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
 
-        expectTrue(!ctl.isDoorOpen(), "door should remain closed under open threshold");
-        expectTrue(!gpio.isHigh(), "gpio should remain low when door is closed");
+        sensor.emit(0.0);
+        sensor.emit(5.0);
+        sensor.emit(9.0);
+
+        expectTrue(!controller.isDoorOpen(), "door should remain closed under open threshold");
+        expectTrue(!gpio.isHigh(), "gpio should remain low while door is closed");
         expectEqInt(gpio.highCalls(), 0, "setHigh should not be called");
         expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
+        expectNear(controller.lastLux(), 9.0, "lastLux should track the latest sample");
     }
 
     {
-        FakeLightSensor sensor({0.0, 31.0});
+        FakeLightSensor sensor;
         FakeGpioOutput gpio;
-        DoorLightController ctl(sensor, gpio, 30.0, 10.0);
+        DoorLightController controller(gpio, 30.0, 10.0);
 
-        ctl.update();
-        ctl.update();
+        int doorEvents = 0;
+        bool lastDoorState = false;
+        double lastEventLux = -1.0;
 
-        expectTrue(ctl.isDoorOpen(), "door should open when lux meets open threshold");
-        expectTrue(gpio.isHigh(), "gpio should be high when door is open");
+        controller.registerDoorStateCallback([&](bool isOpen, double lux) {
+            ++doorEvents;
+            lastDoorState = isOpen;
+            lastEventLux = lux;
+        });
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(0.0);
+        sensor.emit(31.0);
+
+        expectTrue(controller.isDoorOpen(), "door should open when lux meets open threshold");
+        expectTrue(gpio.isHigh(), "gpio should be high after opening");
         expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
         expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
+        expectEqInt(doorEvents, 1, "door state callback should fire once on opening");
+        expectTrue(lastDoorState, "door state callback should report open");
+        expectNear(lastEventLux, 31.0, "door state callback should report latest opening lux");
     }
 
     {
-        FakeLightSensor sensor({35.0, 20.0, 11.0});
+        FakeLightSensor sensor;
         FakeGpioOutput gpio;
-        DoorLightController ctl(sensor, gpio, 30.0, 10.0);
+        DoorLightController controller(gpio, 30.0, 10.0);
 
-        ctl.update(); // open
-        ctl.update(); // still open between thresholds
-        ctl.update(); // still open above close threshold
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
 
-        expectTrue(ctl.isDoorOpen(), "door should remain open above close threshold");
-        expectTrue(gpio.isHigh(), "gpio should remain high while open");
-        expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
-        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
+        sensor.emit(35.0);
+        sensor.emit(20.0);
+        sensor.emit(11.0);
+
+        expectTrue(controller.isDoorOpen(), "door should remain open above close threshold");
+        expectTrue(gpio.isHigh(), "gpio should stay high while still open");
+        expectEqInt(gpio.highCalls(), 1, "setHigh should still only be called once");
+        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called yet");
     }
 
     {
-        FakeLightSensor sensor({35.0, 20.0, 9.0});
+        FakeLightSensor sensor;
         FakeGpioOutput gpio;
-        DoorLightController ctl(sensor, gpio, 30.0, 10.0);
+        DoorLightController controller(gpio, 30.0, 10.0);
 
-        ctl.update(); // open
-        ctl.update(); // still open
-        ctl.update(); // close
+        int doorEvents = 0;
 
-        expectTrue(!ctl.isDoorOpen(), "door should close when lux meets close threshold");
+        controller.registerDoorStateCallback([&](bool, double) {
+            ++doorEvents;
+        });
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(35.0);
+        sensor.emit(20.0);
+        sensor.emit(9.0);
+
+        expectTrue(!controller.isDoorOpen(), "door should close when lux meets close threshold");
         expectTrue(!gpio.isHigh(), "gpio should be low after closing");
         expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
         expectEqInt(gpio.lowCalls(), 1, "setLow should be called once");
+        expectEqInt(doorEvents, 2, "door state callback should fire on open and close");
     }
 
-    if (g_failures == 0) {
+    if (failures == 0) {
         std::cout << "PASS\n";
         return 0;
     }
 
-    std::cout << "FAILURES: " << g_failures << "\n";
+    std::cout << "FAILURES: " << failures << "\n";
     return 1;
 }


### PR DESCRIPTION
This PR rewrites the BH1750 light sensor path in `src/BH1750` to address the earlier feedback about the module being getter based and polling based instead of properly event driven.

- changed `ILightSensor` from a public getter-based interface to a callback-based interface
- added matching `ILightSensor.cpp`
- moved door state handling into `DoorLightController::hasLightSample(...)`
- added door state callback support from the controller
- rewrote `Bh1750Sensor` so it runs a worker thread and emits lux samples through a callback
- used blocking I/O style primitives with `poll()`, `timerfd`, and `eventfd`
- reduced `main.cpp` so it mainly wires components together
- rewrote the unit test to use emitted events instead of polling controller updates
- updated the BH1750 module CMake setup for the new structure

This PR is intended to move the light sensor module toward the event-driven structure requested in feedback:
- callbacks for inter-object communication
- thread wakeup through blocking I/O style primitives
- smaller and clearer main logic
- separate unit test through CMake

## Validation

Tested locally:
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

Tested on Raspberry Pi:
- `cmake -S . -B build -DPIFRIDGE_BUILD_HARDWARE=ON`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- ran `./build/pifridge_light_sensor_demo --interval-ms 500 --open 30 --close 10`

Observed on Pi:
- live lux readings from the BH1750
- state changes between `door=open` and `door=closed` based on thresholds