### PR TITLE
Restore BH1750 test coverage and documentation after integration

### DIFF
--- a/docs/BH1750_realtime_design_hamna.md
+++ b/docs/BH1750_realtime_design_hamna.md
@@ -1,0 +1,101 @@
+# BH1750 realtime design note
+
+## Owner
+
+Hamna Khalid
+
+## Area of responsibility
+
+BH1750 light sensor module refactor and validation:
+- callback-based interface
+- event-driven sensor sampling
+- CMake test integration
+- Raspberry Pi validation
+- BH1750 module documentation update
+
+## Feedback addressed
+
+Earlier feedback identified these problems:
+- getter-based light sensor API
+- no callback registration
+- polling-style flow
+- long and unclear `main`
+- tests not showing event-driven behavior clearly
+
+This refactor addressed that by:
+- replacing the public getter-style interface with callback registration
+- moving sampling into a dedicated worker thread
+- using `timerfd`, `eventfd`, and `poll()` for blocking wakeup
+- moving event handling into `DoorLightController::hasLightSample(...)`
+- restoring a dedicated CMake unit test target
+
+## Callback flow
+
+`Bh1750Sensor`
+-> reads lux sample
+-> invokes registered `LightLevelCallback`
+-> `DoorLightController::hasLightSample(double lux)`
+-> updates door state
+-> invokes registered `DoorStateCallback`
+
+## Realtime rationale
+
+The course requires event-driven C++ code using callbacks and or waking threads through blocking I/O instead of wait-based polling loops.
+
+This module uses:
+- `std::function` callback registration
+- one worker thread in `Bh1750Sensor`
+- `timerfd` to schedule sampling
+- `eventfd` to signal shutdown
+- `poll()` to block until either a timer tick or stop event occurs
+
+This avoids a sleep-based busy loop and keeps the callback path small and deterministic.
+
+## Latency note
+
+Sampling interval is configurable through `start(int intervalMs)`.
+
+During standalone Raspberry Pi validation, the demo was run with:
+- `intervalMs = 500`
+- `openThresholdLux = 30`
+- `closeThresholdLux = 10`
+
+The expected response bound is one configured sampling period plus normal Linux scheduling overhead. For fridge door detection this is acceptable because the event is human-scale and not microsecond-critical.
+
+## Build and test
+
+Use these commands:
+
+    cmake -S src/BH1750 -B src/BH1750/build
+    cmake --build src/BH1750/build
+    ctest --test-dir src/BH1750/build --output-on-failure
+
+## Raspberry Pi validation
+
+Sensor detection on Pi:
+- `/dev/i2c-1`
+- address `0x23` visible in `i2cdetect`
+
+Observed output during live run included:
+
+    door=open lux=425
+    door=closed lux=0.833333
+    door=open lux=69.1667
+    door=closed lux=0.833333
+    door=open lux=31.6667
+    door=closed lux=4.16667
+
+This confirmed:
+- live BH1750 reads worked on hardware
+- thresholds were applied correctly
+- callback-based event handling produced door open and closed transitions on the Pi
+
+## Notes for integration
+
+The callback-based BH1750 core should remain intact during wider integration.
+
+Do not reintroduce:
+- public getter-driven polling flow
+- sleep-based timing loops
+- long sensor-processing logic in `main`
+- removal of module test coverage

--- a/src/BH1750/CMakeLists.txt
+++ b/src/BH1750/CMakeLists.txt
@@ -1,6 +1,21 @@
-add_library(bh1750 STATIC
+cmake_minimum_required(VERSION 3.16)
+project(bh1750 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Threads REQUIRED)
+
+add_library(bh1750_logic STATIC
     ILightSensor.cpp
     DoorLightController.cpp
+)
+
+target_include_directories(bh1750_logic PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_library(bh1750 STATIC
     Bh1750Sensor.cpp
 )
 
@@ -8,3 +23,19 @@ target_include_directories(bh1750 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+target_link_libraries(bh1750 PUBLIC
+    bh1750_logic
+    Threads::Threads
+)
+
+enable_testing()
+
+add_executable(door_light_controller_test
+    test/DoorLightControllerTest.cpp
+)
+
+target_link_libraries(door_light_controller_test PRIVATE
+    bh1750_logic
+)
+
+add_test(NAME door_light_controller_test COMMAND door_light_controller_test)

--- a/src/BH1750/README.md
+++ b/src/BH1750/README.md
@@ -1,87 +1,118 @@
-# Raspberry Pi sensors
+# BH1750 light sensor module
 
-C++ code for Raspberry Pi sensor reads and simple control logic.
-Core logic is unit tested without hardware.
+## Purpose
 
-## Light sensor feature
+This module reads BH1750 lux data on the Raspberry Pi and publishes light samples through callbacks. Door open or closed state is derived from lux thresholds with hysteresis inside `DoorLightController`.
 
-BH1750 light sensor over I2C
-Door open close detection using lux thresholds with hysteresis
-GPIO output to control the fridge light
+This is the event-driven refactor requested in course feedback:
+- no public getter-based polling API
+- sensor samples are pushed through callbacks
+- sensor work runs in its own thread
+- wakeup uses blocking I/O primitives
+- unit test is integrated through CMake
 
-## Wiring BH1750
+## Files
 
-VCC to 3.3V
-GND to GND
-SDA to GPIO2 SDA1 pin 3
-SCL to GPIO3 SCL1 pin 5
+- `include/ILightSensor.hpp`
+- `include/Bh1750Sensor.hpp`
+- `include/DoorLightController.hpp`
+- `ILightSensor.cpp`
+- `Bh1750Sensor.cpp`
+- `DoorLightController.cpp`
+- `test/DoorLightControllerTest.cpp`
 
-Default BH1750 I2C address is 0x23.
-Some boards support 0x5c when address is set high.
+## Design
 
-## Run tests anywhere
+### `ILightSensor`
+Defines the callback-based interface:
+- `registerCallback(...)`
+- `start(int intervalMs)`
+- `stop()`
+
+### `Bh1750Sensor`
+- owns the BH1750 I2C file descriptor
+- runs a worker thread
+- uses `timerfd`, `eventfd`, and `poll()` for blocking wakeup
+- emits lux values through `ILightSensor::LightLevelCallback`
+
+### `DoorLightController`
+- receives lux samples through `hasLightSample(double lux)`
+- applies open and close thresholds with hysteresis
+- emits door state changes through `DoorStateCallback`
+
+## Build and test
 
 ```bash
-cmake -S rpi_sensors -B rpi_sensors/build -G Ninja
-cmake --build rpi_sensors/build
-ctest --test-dir rpi_sensors/build --output-on-failure
+cmake -S src/BH1750 -B src/BH1750/build
+cmake --build src/BH1750/build
+ctest --test-dir src/BH1750/build --output-on-failure
 ```
 
-## Run on Raspberry Pi
+## Packages
 
-Enable I2C in raspi config.
-
-Install dependencies:
+On Debian or Raspberry Pi OS:
 
 ```bash
-sudo apt-get update -y
-sudo apt-get install -y libgpiod-dev i2c-tools cmake ninja-build pkg-config
+sudo apt-get update
+sudo apt-get install -y build-essential cmake pkg-config libi2c-dev i2c-tools
 ```
 
-Confirm sensor is detected:
+## Hardware assumptions
+
+- I2C device path: `/dev/i2c-1`
+- default BH1750 address: `0x23`
+- BH1750 is used in continuous high-resolution mode
+
+Typical wiring:
+- VCC to 3.3V
+- GND to GND
+- SDA to GPIO2 / SDA1
+- SCL to GPIO3 / SCL1
+
+Confirm the sensor is visible:
 
 ```bash
 sudo i2cdetect -y 1
 ```
 
-Build hardware demo:
+## Runtime behavior
 
-```bash
-cmake -S rpi_sensors -B rpi_sensors/build -G Ninja -DPIFRIDGE_BUILD_HARDWARE=ON
-cmake --build rpi_sensors/build
+The sensor thread blocks in `poll()` and wakes when:
+- the periodic `timerfd` expires
+- the `eventfd` stop signal is written
+
+Each wake reads lux once and forwards the value through the registered callback.
+
+## Validation
+
+Validated locally with:
+- CMake configure
+- CMake build
+- CTest unit test
+
+Validated on Raspberry Pi during standalone refactor verification:
+- BH1750 detected on I2C bus 1 at `0x23`
+- callback flow produced correct open and closed transitions from live lux data
+
+Observed Pi output included:
+
+```text
+door=open lux=425
+door=closed lux=0.833333
+door=open lux=69.1667
+door=closed lux=0.833333
 ```
 
-Run demo:
+## Integration note
 
-```bash
-sudo ./rpi_sensors/build/pifridge_light_sensor_demo
-```
+This directory now provides the BH1750 light sensor as a reusable library module for the integrated application. The test target remains here so the callback and controller logic can still be verified independently from wider team integration.
 
-Options:
+## Owner and responsibility
 
-open threshold lux default 30
-close threshold lux default 10
-interval ms default 200
-gpio line default 17
-
-Example:
-
-```bash
-sudo ./rpi_sensors/build/pifridge_light_sensor_demo --open 40 --close 15 --gpio-line 17
-```
-
-If your light wiring is active low:
-
-```bash
-sudo ./rpi_sensors/build/pifridge_light_sensor_demo --active-low
-```
-
-## Calibration
-
-Measure lux with door open and door closed.
-Set open threshold higher than closed lux.
-Set close threshold lower than open threshold to avoid flicker.
-
-## Tracking
-
-This work addresses GitHub issue 6.
+This BH1750 module refactor and validation work was carried out by Hamna Khalid.
+This includes:
+- callback-based light sensor interface
+- event-driven sampling thread
+- CMake test restoration
+- Raspberry Pi validation
+- BH1750 module documentation update

--- a/src/BH1750/test/DoorLightControllerTest.cpp
+++ b/src/BH1750/test/DoorLightControllerTest.cpp
@@ -1,0 +1,191 @@
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include "../include/DoorLightController.hpp"
+#include "../include/ILightSensor.hpp"
+
+class FakeLightSensor : public ILightSensor {
+public:
+    void registerCallback(LightLevelCallback callback) override {
+        callback_ = std::move(callback);
+    }
+
+    void start(int) override {
+    }
+
+    void stop() override {
+    }
+
+    void emit(double lux) {
+        if (callback_) {
+            callback_(lux);
+        }
+    }
+
+private:
+    LightLevelCallback callback_;
+};
+
+class FakeGpioOutput : public IGpioOutput {
+public:
+    FakeGpioOutput() : high_(false), highCalls_(0), lowCalls_(0) {
+    }
+
+    void setHigh() override {
+        high_ = true;
+        ++highCalls_;
+    }
+
+    void setLow() override {
+        high_ = false;
+        ++lowCalls_;
+    }
+
+    bool isHigh() const {
+        return high_;
+    }
+
+    int highCalls() const {
+        return highCalls_;
+    }
+
+    int lowCalls() const {
+        return lowCalls_;
+    }
+
+private:
+    bool high_;
+    int highCalls_;
+    int lowCalls_;
+};
+
+int main() {
+    int failures = 0;
+
+    auto expectTrue = [&](bool cond, const std::string& msg) {
+        if (!cond) {
+            std::cout << "FAIL: " << msg << "\n";
+            ++failures;
+        }
+    };
+
+    auto expectEqInt = [&](int a, int b, const std::string& msg) {
+        if (a != b) {
+            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
+            ++failures;
+        }
+    };
+
+    auto expectNear = [&](double a, double b, const std::string& msg) {
+        if (std::fabs(a - b) > 1e-9) {
+            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
+            ++failures;
+        }
+    };
+
+    {
+        FakeLightSensor sensor;
+        FakeGpioOutput gpio;
+        DoorLightController controller(gpio, 30.0, 10.0);
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(0.0);
+        sensor.emit(5.0);
+        sensor.emit(9.0);
+
+        expectTrue(!controller.isDoorOpen(), "door should remain closed under open threshold");
+        expectTrue(!gpio.isHigh(), "gpio should remain low while door is closed");
+        expectEqInt(gpio.highCalls(), 0, "setHigh should not be called");
+        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
+        expectNear(controller.lastLux(), 9.0, "lastLux should track the latest sample");
+    }
+
+    {
+        FakeLightSensor sensor;
+        FakeGpioOutput gpio;
+        DoorLightController controller(gpio, 30.0, 10.0);
+
+        int doorEvents = 0;
+        bool lastDoorState = false;
+        double lastEventLux = -1.0;
+
+        controller.registerDoorStateCallback([&](bool isOpen, double lux) {
+            ++doorEvents;
+            lastDoorState = isOpen;
+            lastEventLux = lux;
+        });
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(0.0);
+        sensor.emit(31.0);
+
+        expectTrue(controller.isDoorOpen(), "door should open when lux meets open threshold");
+        expectTrue(gpio.isHigh(), "gpio should be high after opening");
+        expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
+        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
+        expectEqInt(doorEvents, 1, "door state callback should fire once on opening");
+        expectTrue(lastDoorState, "door state callback should report open");
+        expectNear(lastEventLux, 31.0, "door state callback should report latest opening lux");
+    }
+
+    {
+        FakeLightSensor sensor;
+        FakeGpioOutput gpio;
+        DoorLightController controller(gpio, 30.0, 10.0);
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(35.0);
+        sensor.emit(20.0);
+        sensor.emit(11.0);
+
+        expectTrue(controller.isDoorOpen(), "door should remain open above close threshold");
+        expectTrue(gpio.isHigh(), "gpio should stay high while still open");
+        expectEqInt(gpio.highCalls(), 1, "setHigh should still only be called once");
+        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called yet");
+    }
+
+    {
+        FakeLightSensor sensor;
+        FakeGpioOutput gpio;
+        DoorLightController controller(gpio, 30.0, 10.0);
+
+        int doorEvents = 0;
+
+        controller.registerDoorStateCallback([&](bool, double) {
+            ++doorEvents;
+        });
+
+        sensor.registerCallback([&controller](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        sensor.emit(35.0);
+        sensor.emit(20.0);
+        sensor.emit(9.0);
+
+        expectTrue(!controller.isDoorOpen(), "door should close when lux meets close threshold");
+        expectTrue(!gpio.isHigh(), "gpio should be low after closing");
+        expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
+        expectEqInt(gpio.lowCalls(), 1, "setLow should be called once");
+        expectEqInt(doorEvents, 2, "door state callback should fire on open and close");
+    }
+
+    if (failures == 0) {
+        std::cout << "PASS\n";
+        return 0;
+    }
+
+    std::cout << "FAILURES: " << failures << "\n";
+    return 1;
+}

--- a/src/BH1750/test/DoorLightControllerTest.cpp
+++ b/src/BH1750/test/DoorLightControllerTest.cpp
@@ -1,184 +1,137 @@
 #include <cmath>
 #include <iostream>
 #include <string>
-#include <utility>
 
 #include "../include/DoorLightController.hpp"
-#include "../include/ILightSensor.hpp"
 
-class FakeLightSensor : public ILightSensor {
-public:
-    void registerCallback(LightLevelCallback callback) override {
-        callback_ = std::move(callback);
+static void expectTrue(bool condition, const std::string& message, int& failures) {
+    if (!condition) {
+        std::cout << "FAIL: " << message << "\n";
+        ++failures;
     }
+}
 
-    void start(int) override {
+static void expectNear(double actual, double expected, double tolerance,
+                       const std::string& message, int& failures) {
+    if (std::fabs(actual - expected) > tolerance) {
+        std::cout << "FAIL: " << message
+                  << " expected " << expected
+                  << " got " << actual << "\n";
+        ++failures;
     }
-
-    void stop() override {
-    }
-
-    void emit(double lux) {
-        if (callback_) {
-            callback_(lux);
-        }
-    }
-
-private:
-    LightLevelCallback callback_;
-};
-
-class FakeGpioOutput : public IGpioOutput {
-public:
-    FakeGpioOutput() : high_(false), highCalls_(0), lowCalls_(0) {
-    }
-
-    void setHigh() override {
-        high_ = true;
-        ++highCalls_;
-    }
-
-    void setLow() override {
-        high_ = false;
-        ++lowCalls_;
-    }
-
-    bool isHigh() const {
-        return high_;
-    }
-
-    int highCalls() const {
-        return highCalls_;
-    }
-
-    int lowCalls() const {
-        return lowCalls_;
-    }
-
-private:
-    bool high_;
-    int highCalls_;
-    int lowCalls_;
-};
+}
 
 int main() {
     int failures = 0;
 
-    auto expectTrue = [&](bool cond, const std::string& msg) {
-        if (!cond) {
-            std::cout << "FAIL: " << msg << "\n";
-            ++failures;
-        }
-    };
-
-    auto expectEqInt = [&](int a, int b, const std::string& msg) {
-        if (a != b) {
-            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
-            ++failures;
-        }
-    };
-
-    auto expectNear = [&](double a, double b, const std::string& msg) {
-        if (std::fabs(a - b) > 1e-9) {
-            std::cout << "FAIL: " << msg << " expected " << b << " got " << a << "\n";
-            ++failures;
-        }
-    };
-
     {
-        FakeLightSensor sensor;
-        FakeGpioOutput gpio;
-        DoorLightController controller(gpio, 30.0, 10.0);
-
-        sensor.registerCallback([&controller](double lux) {
-            controller.hasLightSample(lux);
-        });
-
-        sensor.emit(0.0);
-        sensor.emit(5.0);
-        sensor.emit(9.0);
-
-        expectTrue(!controller.isDoorOpen(), "door should remain closed under open threshold");
-        expectTrue(!gpio.isHigh(), "gpio should remain low while door is closed");
-        expectEqInt(gpio.highCalls(), 0, "setHigh should not be called");
-        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
-        expectNear(controller.lastLux(), 9.0, "lastLux should track the latest sample");
-    }
-
-    {
-        FakeLightSensor sensor;
-        FakeGpioOutput gpio;
-        DoorLightController controller(gpio, 30.0, 10.0);
-
-        int doorEvents = 0;
-        bool lastDoorState = false;
-        double lastEventLux = -1.0;
+        DoorLightController controller(30.0, 10.0);
+        int callbackCount = 0;
+        bool lastState = false;
+        double lastLux = -1.0;
 
         controller.registerDoorStateCallback([&](bool isOpen, double lux) {
-            ++doorEvents;
-            lastDoorState = isOpen;
-            lastEventLux = lux;
+            ++callbackCount;
+            lastState = isOpen;
+            lastLux = lux;
         });
 
-        sensor.registerCallback([&controller](double lux) {
-            controller.hasLightSample(lux);
-        });
+        controller.hasLightSample(0.0);
+        controller.hasLightSample(5.0);
+        controller.hasLightSample(9.0);
 
-        sensor.emit(0.0);
-        sensor.emit(31.0);
-
-        expectTrue(controller.isDoorOpen(), "door should open when lux meets open threshold");
-        expectTrue(gpio.isHigh(), "gpio should be high after opening");
-        expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
-        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called");
-        expectEqInt(doorEvents, 1, "door state callback should fire once on opening");
-        expectTrue(lastDoorState, "door state callback should report open");
-        expectNear(lastEventLux, 31.0, "door state callback should report latest opening lux");
+        expectTrue(!controller.isDoorOpen(),
+                   "door should remain closed below open threshold",
+                   failures);
+        expectTrue(callbackCount == 0,
+                   "callback should not fire while state does not change",
+                   failures);
+        expectNear(controller.lastLux(), 9.0, 1e-9,
+                   "lastLux should track most recent sample",
+                   failures);
+        (void)lastState;
+        (void)lastLux;
     }
 
     {
-        FakeLightSensor sensor;
-        FakeGpioOutput gpio;
-        DoorLightController controller(gpio, 30.0, 10.0);
+        DoorLightController controller(30.0, 10.0);
+        int callbackCount = 0;
+        bool lastState = false;
+        double lastLux = -1.0;
 
-        sensor.registerCallback([&controller](double lux) {
-            controller.hasLightSample(lux);
+        controller.registerDoorStateCallback([&](bool isOpen, double lux) {
+            ++callbackCount;
+            lastState = isOpen;
+            lastLux = lux;
         });
 
-        sensor.emit(35.0);
-        sensor.emit(20.0);
-        sensor.emit(11.0);
+        controller.hasLightSample(31.0);
 
-        expectTrue(controller.isDoorOpen(), "door should remain open above close threshold");
-        expectTrue(gpio.isHigh(), "gpio should stay high while still open");
-        expectEqInt(gpio.highCalls(), 1, "setHigh should still only be called once");
-        expectEqInt(gpio.lowCalls(), 0, "setLow should not be called yet");
+        expectTrue(controller.isDoorOpen(),
+                   "door should open when sample reaches open threshold",
+                   failures);
+        expectTrue(callbackCount == 1,
+                   "callback should fire once on open transition",
+                   failures);
+        expectTrue(lastState,
+                   "callback state should report open",
+                   failures);
+        expectNear(lastLux, 31.0, 1e-9,
+                   "callback lux should report opening sample",
+                   failures);
     }
 
     {
-        FakeLightSensor sensor;
-        FakeGpioOutput gpio;
-        DoorLightController controller(gpio, 30.0, 10.0);
-
-        int doorEvents = 0;
+        DoorLightController controller(30.0, 10.0);
+        int callbackCount = 0;
 
         controller.registerDoorStateCallback([&](bool, double) {
-            ++doorEvents;
+            ++callbackCount;
         });
 
-        sensor.registerCallback([&controller](double lux) {
-            controller.hasLightSample(lux);
+        controller.hasLightSample(35.0);
+        controller.hasLightSample(20.0);
+        controller.hasLightSample(11.0);
+
+        expectTrue(controller.isDoorOpen(),
+                   "door should stay open while above close threshold",
+                   failures);
+        expectTrue(callbackCount == 1,
+                   "callback count should remain one while state stays open",
+                   failures);
+        expectNear(controller.lastLux(), 11.0, 1e-9,
+                   "lastLux should update even without state change",
+                   failures);
+    }
+
+    {
+        DoorLightController controller(30.0, 10.0);
+        int callbackCount = 0;
+        bool lastState = true;
+        double lastLux = -1.0;
+
+        controller.registerDoorStateCallback([&](bool isOpen, double lux) {
+            ++callbackCount;
+            lastState = isOpen;
+            lastLux = lux;
         });
 
-        sensor.emit(35.0);
-        sensor.emit(20.0);
-        sensor.emit(9.0);
+        controller.hasLightSample(35.0);
+        controller.hasLightSample(20.0);
+        controller.hasLightSample(9.0);
 
-        expectTrue(!controller.isDoorOpen(), "door should close when lux meets close threshold");
-        expectTrue(!gpio.isHigh(), "gpio should be low after closing");
-        expectEqInt(gpio.highCalls(), 1, "setHigh should be called once");
-        expectEqInt(gpio.lowCalls(), 1, "setLow should be called once");
-        expectEqInt(doorEvents, 2, "door state callback should fire on open and close");
+        expectTrue(!controller.isDoorOpen(),
+                   "door should close when sample goes below close threshold",
+                   failures);
+        expectTrue(callbackCount == 2,
+                   "callback should fire once for open and once for close",
+                   failures);
+        expectTrue(!lastState,
+                   "callback state should report closed",
+                   failures);
+        expectNear(lastLux, 9.0, 1e-9,
+                   "callback lux should report closing sample",
+                   failures);
     }
 
     if (failures == 0) {


### PR DESCRIPTION
## Summary

This PR cleans up the integrated BH1750 light sensor module after the component merge on `main`.

The callback-based BH1750 core is already present on latest `main`, but some grading-critical pieces for this module were lost or left outdated during integration. This PR restores those without changing the integrated sensor architecture.

## What this PR changes

- restores the BH1750 unit test path in `src/BH1750/test`
- updates the BH1750 unit test so it matches the latest integrated `DoorLightController` API
- restores CMake test integration for the BH1750 module
- rewrites `src/BH1750/README.md` so it matches the latest integrated callback-based module instead of the old `rpi_sensors` / Ninja setup
- adds a BH1750 realtime design and validation note under `docs/` to clearly document the event-driven design, Pi validation, and ownership of this module work

## Why this is needed

Latest `main` kept the callback/threaded BH1750 sensor core, but:
- the BH1750 test folder had been removed
- the module README still described the older setup and outdated commands
- the BH1750 module needed clearer reproducibility and validation evidence for marking

This PR is intended to protect testing, reproducibility, and clear ownership of the BH1750 work without undoing the team integration.

## Validation

Validated on this branch with:

- `cmake -S src/BH1750 -B src/BH1750/build`
- `cmake --build src/BH1750/build`
- `ctest --test-dir src/BH1750/build --output-on-failure`

Earlier standalone BH1750 refactor validation on Raspberry Pi confirmed:
- BH1750 detected on I2C bus 1 at `0x23`
- callback-based lux sampling worked on hardware
- open / closed transitions were observed from live sensor readings

## Notes

This PR is a cleanup and grading-safety PR for the BH1750 area on top of latest integrated `main`. It does not try to revert the overall team integration direction.