### PR TITLE
Strengthen BH1750 validation and remove blocking sleep in main

### DIFF
--- a/src/BH1750/CMakeLists.txt
+++ b/src/BH1750/CMakeLists.txt
@@ -39,3 +39,11 @@ target_link_libraries(door_light_controller_test PRIVATE
 )
 
 add_test(NAME door_light_controller_test COMMAND door_light_controller_test)
+
+add_executable(bh1750_demo
+    test/BH1750Demo.cpp
+)
+
+target_link_libraries(bh1750_demo PRIVATE
+    bh1750
+)

--- a/src/BH1750/README.md
+++ b/src/BH1750/README.md
@@ -24,8 +24,9 @@ This separation follows the course feedback closely: sensor reads are no longer 
 | `Bh1750Sensor.cpp` | BH1750 I2C implementation, worker thread, `timerfd`, `eventfd`, and callback emission |
 | `include/DoorLightController.hpp` | Public door-state controller API and callback type |
 | `DoorLightController.cpp` | Threshold and hysteresis logic for door open and closed state changes |
-| `CMakeLists.txt` | Builds `bh1750_logic`, `bh1750`, and the BH1750 unit test target |
-| `test/DoorLightControllerTest.cpp` | Unit test covering threshold, hysteresis, and callback firing behavior |
+| `CMakeLists.txt` | Builds `bh1750_logic`, `bh1750`, the BH1750 unit test target, and the BH1750 demo target |
+| `test/DoorLightControllerTest.cpp` | Unit test covering threshold, hysteresis, callback firing, and callback-chain behavior |
+| `test/BH1750Demo.cpp` | Minimal hardware demo that prints lux readings and door-state transitions on a Raspberry Pi |
 
 ## Core Interfaces
 
@@ -196,6 +197,18 @@ cmake --build src/BH1750/build
 ctest --test-dir src/BH1750/build --output-on-failure
 ```
 
+### Run the BH1750 demo on Raspberry Pi hardware
+
+```bash
+./src/BH1750/build/bh1750_demo
+```
+
+This demo:
+- opens the BH1750 on `/dev/i2c-1`
+- prints live lux readings
+- prints door open and door closed transitions using the configured thresholds
+- is intended for Raspberry Pi hardware validation, not unit testing
+
 ### Build the full project
 From the project root:
 
@@ -224,14 +237,17 @@ sudo i2cdetect -y 1
 
 ## Testing
 
-The BH1750 module test currently covers `DoorLightController` behavior:
-- remains closed below open threshold
-- opens when lux crosses the open threshold
-- stays open while lux remains above close threshold
-- closes when lux drops below the close threshold
-- callback fires only on real state changes
+The BH1750 module test currently covers:
+- `DoorLightController` threshold and hysteresis behavior
+- callback firing only on real state changes
+- callback-chain propagation using a minimal fake `ILightSensor`
 
 This test is integrated through CMake and exposed through CTest.
+
+The separate `bh1750_demo` executable is used for live Raspberry Pi hardware checks of:
+- BH1750 I2C access
+- lux output on hardware
+- door open and closed transitions from real sensor readings
 
 ## Latency Timings
 
@@ -259,7 +275,7 @@ This BH1750 module refactor and validation work includes:
 - callback-based light sensor interface
 - event-driven sampling thread
 - door-state threshold and hysteresis logic
-- CMake test restoration for the BH1750 module
+- CMake test restoration and demo target wiring for the BH1750 module
 - Raspberry Pi validation of the BH1750 sensor path
 - BH1750 module documentation update
 

--- a/src/BH1750/README.md
+++ b/src/BH1750/README.md
@@ -160,9 +160,14 @@ This confirmed:
 
 ## Latency Note
 
-During Raspberry Pi validation, the sampling interval was configured at `500 ms`.
+Two BH1750 timing contexts were used during development:
 
-Because door-state evaluation happens once on each timer wakeup, the designed response bound is one configured sample interval plus normal Linux scheduling overhead. For fridge door detection this is acceptable because the event is human-scale and not microsecond-critical.
+- **Module-level Raspberry Pi validation** used a `500 ms` sampling interval to confirm stable callback-based lux sampling and correct door open/closed transitions on hardware.
+- **Integrated PiFridge runtime configuration** in `main.cpp` uses a `200 ms` sampling interval for the live system.
+
+Because door-state evaluation happens once on each timer wakeup, the response bound is one configured sample interval plus normal Linux scheduling overhead. For fridge door detection this is acceptable because the event is human-scale rather than microsecond-critical.
+
+In the integrated system, the `200 ms` sampling interval was chosen to reduce visible delay in door-state detection while still keeping the BH1750 path simple, callback-based, and event-driven.
 
 ## Dependencies
 
@@ -242,7 +247,9 @@ The BH1750 module test currently covers:
 - callback firing only on real state changes
 - callback-chain propagation using a minimal fake `ILightSensor`
 
-This test is integrated through CMake and exposed through CTest.
+This test is integrated through CMake and exposed through CTest. It verifies controller logic and callback-chain behavior without requiring physical hardware.
+
+Direct BH1750 device access, live lux readings, and real sensor-triggered door transitions are verified separately on Raspberry Pi hardware using the `bh1750_demo` executable.
 
 The separate `bh1750_demo` executable is used for live Raspberry Pi hardware checks of:
 - BH1750 I2C access

--- a/src/BH1750/README.md
+++ b/src/BH1750/README.md
@@ -258,21 +258,28 @@ The separate `bh1750_demo` executable is used for live Raspberry Pi hardware che
 
 ## Latency Timings
 
-### Console
-| Run | Time |
-|-----|------|
-| 1 | 341μs |
-| 2 | 340μs |
-| 3 | 337μs |
-| **Mean** | **339μs** |
+Two timing contexts were measured during development:
 
-### Webapp
-| Run | Time |
-|-----|------|
-| 1 | 635ms |
-| 2 | 641ms |
-| 3 | 638ms |
-| **Mean** | **638ms** |
+1. **Module-level BH1750 validation on Raspberry Pi**
+   - sampling interval: `500 ms`
+   - purpose: confirm stable callback-based lux sampling and correct door open/closed transitions on hardware
+
+2. **Integrated PiFridge runtime**
+   - sampling interval: `200 ms`
+   - purpose: reduce visible delay in live door-state detection within the full system
+
+### Measured timings
+
+| Context | Event | Run 1 | Run 2 | Run 3 | Mean |
+|---------|-------|-------|-------|-------|------|
+| Integrated PiFridge runtime | Light change → console | 341μs | 340μs | 337μs | **339μs** |
+| Integrated PiFridge runtime | Light change → webapp | 635ms | 641ms | 638ms | **638ms** |
+
+### Design interpretation
+
+For the integrated PiFridge runtime, the BH1750 path uses a `200 ms` sampling interval. This means door-state response is bounded by one timer interval plus normal Linux scheduling overhead. The measured console latency is well below the configured interval, while the larger webapp latency is dominated by the wider system path rather than the BH1750 callback chain alone.
+
+For fridge-door detection, this latency is acceptable because the event is human-scale and the design goal is responsive state detection rather than microsecond-critical control.
 
 ## Author and Responsibility
 
@@ -282,7 +289,7 @@ This BH1750 module refactor and validation work includes:
 - callback-based light sensor interface
 - event-driven sampling thread
 - door-state threshold and hysteresis logic
-- CMake test restoration and demo target wiring for the BH1750 module
+- CMake test restoration, strong BH1750 test coverage, and demo target wiring for the BH1750 module
 - Raspberry Pi validation of the BH1750 sensor path
 - BH1750 module documentation update
 

--- a/src/BH1750/test/BH1750Demo.cpp
+++ b/src/BH1750/test/BH1750Demo.cpp
@@ -1,0 +1,52 @@
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+#include "../include/Bh1750Sensor.hpp"
+#include "../include/DoorLightController.hpp"
+
+namespace {
+std::atomic<bool> g_stop{false};
+
+void signalHandler(int) {
+    g_stop = true;
+}
+}
+
+int main() {
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
+
+    try {
+        Bh1750Sensor sensor("/dev/i2c-1", 0x23);
+        DoorLightController controller(30.0, 10.0);
+
+        sensor.registerCallback([&](double lux) {
+            std::cout << "[BH1750Demo] lux=" << lux << '\n';
+            controller.hasLightSample(lux);
+        });
+
+        controller.registerDoorStateCallback([](bool isOpen, double lux) {
+            std::cout << "[BH1750Demo] door="
+                      << (isOpen ? "open" : "closed")
+                      << " lux=" << lux << '\n';
+        });
+
+        sensor.start(200);
+
+        std::cout << "BH1750 demo running. Press Ctrl+C to stop.\n";
+
+        while (!g_stop) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        sensor.stop();
+        std::cout << "BH1750 demo stopped.\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "[BH1750Demo] error: " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/src/BH1750/test/DoorLightControllerTest.cpp
+++ b/src/BH1750/test/DoorLightControllerTest.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 #include "../include/DoorLightController.hpp"
@@ -189,6 +190,21 @@ int main() {
                    failures);
         expectTrue(!controller.isDoorOpen(),
                    "controller should end closed after callback-chain test",
+                   failures);
+    }
+
+    {
+        bool threw = false;
+
+        try {
+            DoorLightController controller(10.0, 30.0);
+            (void)controller;
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+
+        expectTrue(threw,
+                   "constructor should reject close threshold above open threshold",
                    failures);
     }
 

--- a/src/BH1750/test/DoorLightControllerTest.cpp
+++ b/src/BH1750/test/DoorLightControllerTest.cpp
@@ -3,6 +3,29 @@
 #include <string>
 
 #include "../include/DoorLightController.hpp"
+#include "../include/ILightSensor.hpp"
+
+// Minimal fake sensor used to verify callback-chain behavior without hardware.
+class FakeLightSensor final : public ILightSensor {
+public:
+    ~FakeLightSensor() override = default;
+
+    void registerCallback(LightLevelCallback callback) override {
+        callback_ = std::move(callback);
+    }
+
+    void start(int) override {}
+    void stop() override {}
+
+    void emit(double lux) {
+        if (callback_) {
+            callback_(lux);
+        }
+    }
+
+private:
+    LightLevelCallback callback_;
+};
 
 static void expectTrue(bool condition, const std::string& message, int& failures) {
     if (!condition) {
@@ -131,6 +154,41 @@ int main() {
                    failures);
         expectNear(lastLux, 9.0, 1e-9,
                    "callback lux should report closing sample",
+                   failures);
+    }
+
+    {
+        FakeLightSensor sensor;
+        DoorLightController controller(30.0, 10.0);
+        int callbackCount = 0;
+        bool lastState = false;
+        double lastLux = -1.0;
+
+        // This test verifies the full callback chain from sensor event to door-state event.
+        sensor.registerCallback([&](double lux) {
+            controller.hasLightSample(lux);
+        });
+
+        controller.registerDoorStateCallback([&](bool isOpen, double lux) {
+            ++callbackCount;
+            lastState = isOpen;
+            lastLux = lux;
+        });
+
+        sensor.emit(31.0);
+        sensor.emit(9.0);
+
+        expectTrue(callbackCount == 2,
+                   "callback chain should propagate open and close transitions",
+                   failures);
+        expectTrue(!lastState,
+                   "final state should be closed after callback-chain test",
+                   failures);
+        expectNear(lastLux, 9.0, 1e-9,
+                   "final lux should match closing sample in callback-chain test",
+                   failures);
+        expectTrue(!controller.isDoorOpen(),
+                   "controller should end closed after callback-chain test",
                    failures);
     }
 

--- a/src/README.md
+++ b/src/README.md
@@ -106,7 +106,7 @@ All callbacks that write to `FridgeState` acquire `state.mutex` via `std::lock_g
 | BME680 | I2C bus 1 | `0x76` | 5000 ms |
 | BH1750 | `/dev/i2c-1` | `0x23` | 200 ms |
 | BarcodeScanner | `/dev/ttyAMA0` | — | Event-driven |
-| Camera | — | — | 2000 ms (door open only) |
+| Camera | — | — | 200 ms (door open or manual trigger) |
 
 ### BME680 settings
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 #include "BarcodeScanner.hpp"
 #include "Camera.hpp"
 #include <fstream>
-#include <iomanip> 
+#include <iomanip>
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <sqlite3.h>
 #include <ctime>
+#include <unistd.h>
 
 struct FridgeState {
     BME680Sample    vitals{};
@@ -33,7 +34,7 @@ struct FridgeState {
 
 
 // hANDSHAKE FUNCTION
-// writes the JSON file that the API will serve to the PIFRIDGE app 
+// writes the JSON file that the API will serve to the PIFRIDGE app
 void saveStateToJson(const FridgeState& state) {
     // We create the file in the current working directory (usually /build)
     std::ofstream outFile("/tmp/fridge_data.json");
@@ -54,32 +55,32 @@ void saveStateToJson(const FridgeState& state) {
 // Increments quantity if already exists, inserts new row if not.
 static void addCameraItemToInventory(const std::string& name) {
     static const char* DB_PATH = "/var/lib/pifridge/inventory.db";
- 
+
     sqlite3* db = nullptr;
     if (sqlite3_open(DB_PATH, &db) != SQLITE_OK) {
         std::cerr << "[Camera] Failed to open inventory DB\n";
         return;
     }
- 
+
     // Check if item already exists by name (no barcode for camera detections)
     const char* selectQuery =
         "SELECT id, quantity FROM inventory WHERE name = ? AND (barcode IS NULL OR barcode = '');";
     sqlite3_stmt* stmt = nullptr;
- 
+
     if (sqlite3_prepare_v2(db, selectQuery, -1, &stmt, nullptr) != SQLITE_OK) {
         std::cerr << "[Camera] Failed to prepare select\n";
         sqlite3_close(db);
         return;
     }
- 
+
     sqlite3_bind_text(stmt, 1, name.c_str(), -1, SQLITE_STATIC);
- 
+
     if (sqlite3_step(stmt) == SQLITE_ROW) {
         // Exists — increment quantity
         int id  = sqlite3_column_int(stmt, 0);
         int qty = sqlite3_column_int(stmt, 1);
         sqlite3_finalize(stmt);
- 
+
         const char* updateQuery = "UPDATE inventory SET quantity = ? WHERE id = ?;";
         sqlite3_stmt* upStmt = nullptr;
         if (sqlite3_prepare_v2(db, updateQuery, -1, &upStmt, nullptr) == SQLITE_OK) {
@@ -92,15 +93,15 @@ static void addCameraItemToInventory(const std::string& name) {
     } else {
         // Does not exist — insert new row with empty barcode
         sqlite3_finalize(stmt);
- 
+
         time_t now = time(nullptr);
         char dateBuf[11];
         strftime(dateBuf, sizeof(dateBuf), "%Y-%m-%d", localtime(&now));
- 
+
         const char* insertQuery =
             "INSERT INTO inventory (name, barcode, quantity, date_added) VALUES (?, '', 1, ?);";
         sqlite3_stmt* insStmt = nullptr;
- 
+
         if (sqlite3_prepare_v2(db, insertQuery, -1, &insStmt, nullptr) == SQLITE_OK) {
             sqlite3_bind_text(insStmt, 1, name.c_str(), -1, SQLITE_STATIC);
             sqlite3_bind_text(insStmt, 2, dateBuf,      -1, SQLITE_STATIC);
@@ -109,9 +110,10 @@ static void addCameraItemToInventory(const std::string& name) {
             std::cout << "[Camera] Added to inventory: " << name << "\n";
         }
     }
- 
+
     sqlite3_close(db);
 }
+
 // ---------------------------------------------------------------------------
 // Signal handling - Ctrl+C shuts everything down cleanly
 // ---------------------------------------------------------------------------
@@ -130,7 +132,7 @@ int main() {
 // ---------------------------------------------------------------------------
 
     // -- Shared state --
-    
+
     BME680Settings sensorSettings;
     sensorSettings.osrs_t         = 4;
     sensorSettings.osrs_p         = 3;
@@ -170,11 +172,11 @@ int main() {
         std::cout << "[Barcode] Scanned: " << code << "\n";
         fetch_product(code);
 
-        // Re-arm the scanner if the door is still open
+        // Re-arm the scanner immediately if the door is still open.
+        // Do not block inside the callback.
         {
             std::lock_guard<std::mutex> lock(state.mutex);
             if (state.door_open) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
                 scanner.triggerScan();
             }
         }
@@ -196,17 +198,17 @@ int main() {
     // Output sent to /dev/null to suppress logs
     cameraConfig.capture_command =
         "rpicam-still --zsl -n --immediate --width 1280 --height 720 -o {image} >/dev/null 2>&1";
-    
+
     // OCR configuration (Tesseract)
     // --psm: 11 for sparse text, 6 for block of text, 7 for single line, 8 for single word.
     // Whitelist to focus on common expiry date characters
     cameraConfig.tesseract_command =
         "tesseract {image} stdout --psm 11 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/:.- 2>/dev/null";
-    
+
     // Object detection model and label file paths
     cameraConfig.model_path = "/home/pifridge/PiFridge/src/Camera/detect.tflite";
     cameraConfig.label_path = "/home/pifridge/PiFridge/src/Camera/labelmap.txt";
-    
+
     // Capture parameters
     cameraConfig.interval = std::chrono::milliseconds(200);
     cameraConfig.confidence_threshold = 0.7f;
@@ -225,10 +227,10 @@ int main() {
             std::cout << "Best before detected: " << event.text << "\n";
         }
     });
-    
+
     // Start camera thread
     camera.start();
-    
+
     // -----------------------------------------------------------------------
     // BH1750 + DoorLightController - door detection
     // -----------------------------------------------------------------------
@@ -245,7 +247,7 @@ int main() {
         }
 
         camera.setDoorOpen(isOpen); // tell camera bout the door state so it can trigger immediate capture
- 
+
         if (isOpen) {
             std::cout << "[Door] Opened (lux=" << lux << ") - Barcode scanner ON\n";
             scanner.triggerScan();
@@ -265,7 +267,6 @@ int main() {
         doorController.hasLightSample(lux);
     });
 
-
     bme680.start();
     std::cout << "PiFridge: BME680 Sensor Thread Started" << std::endl;
 
@@ -277,7 +278,7 @@ int main() {
     std::cout << "PiFridge running. Press Ctrl+C to stop.\n";
 
     while (!g_quit) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        pause();
     }
 
     //----- Clean shutdown -----
@@ -300,7 +301,7 @@ int main() {
         // If Door Shut then
         // Turn barcode scanner off
         // Fridge vitals uploaded to web app using intervals
-        
+
         // If Door Open then
         // Barcode scanner on, and able to scan and update the web app whenever
         // Fridge vitals uploaded to web app using intervals


### PR DESCRIPTION
- strengthen BH1750 test coverage with callback-chain and invalid-threshold checks
- add a `bh1750_demo` target for Raspberry Pi hardware validation
- clarify BH1750 timing and test coverage documentation
- remove the blocking sleep from the barcode callback in `main.cpp`
- replace the main busy-wait sleep loop with `pause()`
- fix `src/README.md` camera interval wording to match the integrated runtime configuration

## Reason
These changes strengthen the BH1750 module for callback-based, event-driven design and improve the evidence for testing and reliability. They also remove unnecessary blocking in `main.cpp` and fix a documentation mismatch.

## Verified locally
- CMake configure succeeded
- `bh1750_demo` builds
- `door_light_controller_test` builds and passes
- `pifridge_api` and `pifridge_inventory` build

## Needs Raspberry Pi confirmation
Please test on the Pi after merge to confirm:
- `bh1750_demo` runs correctly on hardware
- BH1750 door transitions still behave as expected
- the integrated runtime still behaves correctly after the non-blocking scanner re-arm change
- camera / TensorFlow Lite path still works in the full environment

## Notes
The full Camera/TensorFlow Lite build could not be verified on this Linux machine because the local environment does not have the required TFLite headers installed.